### PR TITLE
Allow configuring the VPN init timeout

### DIFF
--- a/forticlient
+++ b/forticlient
@@ -1,6 +1,6 @@
 #!/usr/bin/expect -f
 
-set timeout 5
+set timeout $env(VPNTIMEOUT)
 
 spawn "/usr/share/forticlient/opt/forticlient-sslvpn/64bit/forticlientsslvpn_cli" --server $env(VPNADDR) --vpnuser $env(VPNUSER) --keepalive
 
@@ -19,7 +19,7 @@ expect -exact "Would you like to connect to this server? (Y/N)" {
 expect {
   "STATUS::Tunnel running" {
   } timeout {
-    send_user -- "Failed to bring tunnel up after 10s\n"
+    send_user -- "Failed to bring tunnel up after $env(VPNTIMEOUT)s\n"
     exit 1
   }
 }
@@ -34,4 +34,3 @@ expect {
     exit
   }
 }
-

--- a/start.sh
+++ b/start.sh
@@ -4,6 +4,8 @@ if [ -z "$VPNADDR" -o -z "$VPNUSER" -o -z "$VPNPASS" ]; then
   echo "Variables VPNADDR, VPNUSER and VPNPASS must be set."; exit;
 fi
 
+export VPNTIMEOUT=${VPNTIMEOUT:-5}
+
 # Setup masquerade, to allow using the container as a gateway
 for iface in $(ip a | grep eth | grep inet | awk '{print $2}'); do
   iptables -t nat -A POSTROUTING -s "$iface" -j MASQUERADE


### PR DESCRIPTION
I'm connecting to a VPN in which more than 10 seconds are needed to bring the tunnel up. This PR allows users to optionally configure the init timeout, with a default of 5 seconds as before.
